### PR TITLE
Fix bug with valid field not included in output

### DIFF
--- a/goalfred.go
+++ b/goalfred.go
@@ -31,13 +31,14 @@ type AlfredItem interface {
 }
 
 // Item stores informations about on item in the script filter
+// A possible gotcha here is the `Valid` attribute, which is a pointer to a bool. This ensures it is whatever you set it and it gets included in the output if and only if you set it.
 type Item struct {
 	UID          string      `json:"uid,omitempty"`
 	Title        string      `json:"title"`
 	Subtitle     string      `json:"subtitle"`
 	Arg          string      `json:"arg,omitempty"`
 	Icon         *Icon       `json:"icon,omitempty"`
-	Valid        bool        `json:"valid,omitempty"`
+	Valid        *bool       `json:"valid,omitempty"`
 	Autocomplete string      `json:"autocomplete,omitempty"`
 	Type         string      `json:"type,omitempty"`
 	Mod          ModElements `json:"mods,omitempty"`


### PR DESCRIPTION
The problem is that go doesn't include 'valid' in the output if it set to false, which appears to be [by design](https://github.com/golang/go/issues/13284), since false is the 'nil-value' for a bool. Since that's an issue though as Alfred defaults to true for a missing 'valid', this doesn't work.

There's two options here. Either make 'valid' a pointer allowing for all three cases (true, false and nil) or make 'valid' not 'omitempty' but default it to true in a constructor function. Since there's no way to
ensure however that a user actually uses that constructor (unless the type is no longer exported, but that's also kinda weird), that would only result in unexpected behavior. The only sane, albeit a bit weird, solution is the pointer^^

Yay for long explanation \o/ :D 
