### PR TITLE
Add function to normalize Alfred input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # master
 
 - Added danger support (@BenchR267)
+- Add support for re-normalizing user input (@kiliankoe)

--- a/normalize.go
+++ b/normalize.go
@@ -1,0 +1,25 @@
+package goalfred
+
+import (
+	"io/ioutil"
+	"os/exec"
+)
+
+// Normalize fixes problems with string encoding regarding the usage of special characters in Alfred.
+// For more info on this topic, please refer to this thread: http://www.alfredforum.com/topic/2015-encoding-issue/
+func Normalize(input string) (output string, err error) {
+	iconv := exec.Command("iconv", "-f", "UTF8-MAC")
+	iconvIn, err := iconv.StdinPipe()
+	iconvOut, err := iconv.StdoutPipe()
+
+	iconv.Start()
+	iconvIn.Write([]byte(input))
+	iconvIn.Close()
+
+	iconvOutput, err := ioutil.ReadAll(iconvOut)
+	iconv.Wait()
+
+	output = string(iconvOutput)
+
+	return
+}

--- a/response.go
+++ b/response.go
@@ -18,6 +18,9 @@ func NormalizedArguments() (normalizedArgs []string, err error) {
 	for _, e := range Arguments() {
 		var normalizedElement string
 		normalizedElement, err = Normalize(e)
+		if err != nil {
+			return
+		}
 		normalizedArgs = append(normalizedArgs, normalizedElement)
 	}
 	return

--- a/response.go
+++ b/response.go
@@ -6,16 +6,21 @@ import (
 	"os"
 )
 
-// Argument just wrappes the call to os.Args for better readability
-func Argument() string {
-	return os.Args[1]
+// Arguments just wrappes the call to os.Args for better readability
+func Arguments() []string {
+	return os.Args[1:]
 }
 
-// NormalizedArgument re-normalizes the user argument provided via Alfred.
+// NormalizedArguments re-normalizes the user arguments provided via Alfred.
 // This isn't necessary for every workflow, specifically only when you're working with special characters.
 // For more info on this topic, please refer to this thread: http://www.alfredforum.com/topic/2015-encoding-issue/
-func NormalizedArgument() (string, error) {
-	return Normalize(Argument())
+func NormalizedArguments() (normalizedArgs []string, err error) {
+	for _, e := range Arguments() {
+		var normalizedElement string
+		normalizedElement, err = Normalize(e)
+		normalizedArgs = append(normalizedArgs, normalizedElement)
+	}
+	return
 }
 
 // Response is the top level domain object.

--- a/response.go
+++ b/response.go
@@ -14,12 +14,13 @@ func Arguments() []string {
 // NormalizedArguments re-normalizes the user arguments provided via Alfred.
 // This isn't necessary for every workflow, specifically only when you're working with special characters.
 // For more info on this topic, please refer to this thread: http://www.alfredforum.com/topic/2015-encoding-issue/
+// Arguments that couldn't get normalized are not part of the return value!
 func NormalizedArguments() (normalizedArgs []string, err error) {
 	for _, e := range Arguments() {
 		var normalizedElement string
 		normalizedElement, err = Normalize(e)
 		if err != nil {
-			return
+			continue
 		}
 		normalizedArgs = append(normalizedArgs, normalizedElement)
 	}

--- a/response.go
+++ b/response.go
@@ -6,9 +6,16 @@ import (
 	"os"
 )
 
-// Arguments just wrappes the call to os.Args for better readability
-func Arguments() []string {
-	return os.Args[1:]
+// Argument just wrappes the call to os.Args for better readability
+func Argument() string {
+	return os.Args[1]
+}
+
+// NormalizedArgument re-normalizes the user argument provided via Alfred.
+// This isn't necessary for every workflow, specifically only when you're working with special characters.
+// For more info on this topic, please refer to this thread: http://www.alfredforum.com/topic/2015-encoding-issue/
+func NormalizedArgument() (string, error) {
+	return Normalize(Argument())
 }
 
 // Response is the top level domain object.


### PR DESCRIPTION
For problems regarding http://www.alfredforum.com/topic/2015-encoding-issue/

I've previously been using something directly in go, but that was far from perfect... And iconv should be installed on every Mac anyways.
