### PR TITLE
Add IsDebug() and Log()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+- Add Log and IsDebug functions (@kiliankoe)
 - Removed Response struct, added package wide result handling (@BenchR267)
 - Added code coverage to README (@BenchR267)
 - Add tests (@kiliankoe)

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,20 @@
+package goalfred
+
+import (
+	"fmt"
+	"os"
+)
+
+// IsDebug returns if the current environment has 'alfred_debug' set.
+func IsDebug() bool {
+	alfredDebug := os.Getenv("alfred_debug")
+	return alfredDebug != ""
+}
+
+// Log logs text to the debug panel. Only logs when IsDebug is true, so as not
+// to interfere with the normal output.
+func Log(text string) {
+	if IsDebug() {
+		fmt.Println(text)
+	}
+}

--- a/debug.go
+++ b/debug.go
@@ -1,7 +1,7 @@
 package goalfred
 
 import (
-	"fmt"
+	"log"
 	"os"
 )
 
@@ -15,6 +15,6 @@ func IsDebug() bool {
 // to interfere with the normal output.
 func Log(text string) {
 	if IsDebug() {
-		fmt.Println(text)
+		log.Println(text)
 	}
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -1,0 +1,48 @@
+package goalfred
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestIsDebug(t *testing.T) {
+	os.Unsetenv("alfred_debug")
+	if IsDebug() {
+		t.Errorf("Expected return value of IsDebug to be false if env var is not set.")
+	}
+
+	os.Setenv("alfred_debug", "true")
+	if !IsDebug() {
+		t.Errorf("Expected return value of IsDebug to be true if env var is set.")
+	}
+}
+
+// thanks to http://stackoverflow.com/a/26806093
+func captureOutput(f func()) string {
+	var buf bytes.Buffer
+	log.SetFlags(0)
+	log.SetOutput(&buf)
+	f()
+	log.SetOutput(os.Stdin)
+	return buf.String()
+}
+
+func TestLog(t *testing.T) {
+	os.Unsetenv("alfred_debug")
+	emptyOutput := captureOutput(func() {
+		Log("some log")
+	})
+	if emptyOutput != "" {
+		t.Errorf("Expected output to be empty since debug is not turned on. Got: %s", emptyOutput)
+	}
+
+	os.Setenv("alfred_debug", "true")
+	someOutput := captureOutput(func() {
+		Log("some log")
+	})
+	if someOutput != "some log\n" {
+		t.Errorf("Expected output to be 'some log' since debug is turned on. Got: %s", someOutput)
+	}
+}


### PR DESCRIPTION
`Log()` only logs to STDOUT if the debug panel is open.
